### PR TITLE
Hierarchy of DMNModelInstrumentedBase.

### DIFF
--- a/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/DMNElementConverter.java
+++ b/kie-dmn-backend/src/main/java/org/kie/dmn/backend/marshalling/v1_1/xstream/DMNElementConverter.java
@@ -24,24 +24,27 @@ import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
 import org.kie.dmn.feel.model.v1_1.DMNElement;
 
 public abstract class DMNElementConverter
-        extends DMNBaseConverter {
+        extends DMNModelInstrumentedBaseConverter {
     public static final String ID          = "id";
     public static final String LABEL       = "label";
     public static final String DESCRIPTION = "description";
 
     public DMNElementConverter(XStream xstream) {
-        super( xstream.getMapper() );
+        super( xstream );
     }
 
     @Override
     protected void assignChildElement(Object parent, String nodeName, Object child) {
         if ( DESCRIPTION.equals( nodeName ) && child instanceof String ) {
             ((DMNElement) parent).setDescription( (String) child );
+        } else {
+            super.assignChildElement(parent, nodeName, child);
         }
     }
 
     @Override
     protected void assignAttributes(HierarchicalStreamReader reader, Object parent) {
+        super.assignAttributes(reader, parent);
         String id = reader.getAttribute( ID );
         String label = reader.getAttribute( LABEL );
 
@@ -53,7 +56,7 @@ public abstract class DMNElementConverter
     
     @Override
     protected void writeChildren(HierarchicalStreamWriter writer, MarshallingContext context, Object parent) {
-        // there is no call to super as super is an abstract method.
+        super.writeChildren(writer, context, parent);
         DMNElement e = (DMNElement) parent;
 
         if (e.getDescription() !=null) writeChildrenNodeAsValue(writer, context, e.getDescription(), DESCRIPTION);
@@ -61,7 +64,7 @@ public abstract class DMNElementConverter
     }
     @Override
     protected void writeAttributes(HierarchicalStreamWriter writer, Object parent) {
-        // there is no call to super as super is an abstract method.
+        super.writeAttributes(writer, parent);
         DMNElement e = (DMNElement) parent;
         
         if (e.getId() != null) writer.addAttribute( ID , e.getId() );

--- a/kie-dmn-model/src/main/java/org/kie/dmn/feel/model/v1_1/DMNModelInstrumentedBase.java
+++ b/kie-dmn-model/src/main/java/org/kie/dmn/feel/model/v1_1/DMNModelInstrumentedBase.java
@@ -16,6 +16,6 @@
 
 package org.kie.dmn.feel.model.v1_1;
 
-public class DMNModelInstrumentedBase {
+public abstract class DMNModelInstrumentedBase {
 
 }


### PR DESCRIPTION
Assuming:
- `DMNModelInstrumentedBase` was artificially introduced as a "super parent" for DMN model classes representing the DMN XSD

Given:
- `DMNElementConverter` in its [original commit](https://github.com/jboss-integration/kie-dmn/blob/2f88891cf8b63e77bb2a890d449c3ef6babf958b/kie-dmn-backend/src/main/java/org/kie/dmn/backend/unmarshalling/v1_1/xstream/DMNElementConverter.java#L24) (1) was wrongly inheriting directly from the base converter instead of respecting the same relationship as in the model classes

I then propose:
1. make `DMNModelInstrumentedBase` abstract as anyway it does not hold any representation in the original DMN XSD
2. have `DMNElementConverter` actually to extend from `DMNModelInstrumentedBaseConverter`, given `DMNElement` extends form `DMNModelInstrumentedBase` (like any other DMN model class extends from DMNModelInstrumentedBase)

(1) https://github.com/jboss-integration/kie-dmn/blob/2f88891cf8b63e77bb2a890d449c3ef6babf958b/kie-dmn-backend/src/main/java/org/kie/dmn/backend/unmarshalling/v1_1/xstream/DMNElementConverter.java#L24
