### PR TITLE
JavaBackedType cache.

### DIFF
--- a/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/JavaBackedType.java
+++ b/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/JavaBackedType.java
@@ -1,26 +1,50 @@
 package org.kie.dmn.feel.lang.impl;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.kie.dmn.feel.lang.CustomType;
 import org.kie.dmn.feel.lang.FEELProperty;
 import org.kie.dmn.feel.lang.Property;
+import org.kie.dmn.feel.lang.Type;
+import org.kie.dmn.feel.lang.types.BuiltInType;
 import org.kie.dmn.feel.parser.feel11.ParserHelper;
 
 public class JavaBackedType implements CustomType {
+    private static Map<Class<?>, JavaBackedType> cache = new HashMap<>();
+    
     private Class<?> wrapped;
     private Map<String, Property> properties = new HashMap<>();
 
-    public JavaBackedType(Class<?> class1) {
+    private JavaBackedType(Class<?> class1) {
         this.wrapped = class1;
         Stream.of( class1.getMethods() )
             .filter( m -> m.getAnnotation(FEELProperty.class) != null )
             .forEach( m -> properties.put( m.getAnnotation(FEELProperty.class).value() , new PropertyImpl( m.getAnnotation(FEELProperty.class).value() , ParserHelper.determineTypeFromClass(m.getReturnType()) ) ) );
             ;
+    }
+    
+    /**
+     * If clazz can be represented as a JavaBackedType, returns a JavaBackedType for representing clazz.
+     * If clazz can not be represented as a JavaBackedType, returns BuiltInType.UNKNOWN.
+     * This method performs memoization when necessary.
+     * @param clazz the class to be represented as JavaBackedType
+     * @return JavaBackedType representing clazz or BuiltInType.UNKNOWN
+     */
+    public static Type of(Class<?> clazz) {
+        return Optional.ofNullable( (Type) cache.computeIfAbsent( clazz, JavaBackedType::createIfAnnotated ) ).orElse( BuiltInType.UNKNOWN );
+    }
+    
+    /**
+     * For internal use, returns a new JavaBackedType if clazz can be represented as such, returns null otherwise.
+     */
+    private static JavaBackedType createIfAnnotated(Class<?> clazz) {
+        if (Stream.of(clazz.getMethods()).anyMatch(m->m.getAnnotation(FEELProperty.class)!=null)) {
+            return new JavaBackedType(clazz) ;
+        }
+        return null;
     }
 
     @Override

--- a/kie-dmn-feel/src/main/java/org/kie/dmn/feel/parser/feel11/ParserHelper.java
+++ b/kie-dmn-feel/src/main/java/org/kie/dmn/feel/parser/feel11/ParserHelper.java
@@ -190,10 +190,8 @@ public class ParserHelper {
             return BuiltInType.LIST;
         } else if( Map.class.isAssignableFrom(clazz) ) {     // TODO not so sure about this one..
             return BuiltInType.CONTEXT;
-        } else if (Stream.of(clazz.getMethods()).anyMatch(m->m.getAnnotation(FEELProperty.class)!=null)) {
-            return new JavaBackedType(clazz);
-        }
-        return BuiltInType.UNKNOWN;
+        } 
+        return JavaBackedType.of( clazz ); 
     }
 
 }

--- a/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELStaticTypeTest.java
+++ b/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELStaticTypeTest.java
@@ -26,6 +26,7 @@ import org.kie.dmn.feel.runtime.impl.RangeImpl;
 import test.Address;
 import test.Person;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Collection;
@@ -71,7 +72,7 @@ public class FEELStaticTypeTest
             
                 { "{ myFeelVar : person.first name + person.last name }",
                   new HashMap<String, Type>() {{
-                      put( "person", new JavaBackedType(Person.class) );
+                      put( "person", JavaBackedType.of(Person.class) );
                   }},
                   new HashMap<String, Object>() {{
                       put( "person", new Person("John ", "Doe") ); 
@@ -81,15 +82,38 @@ public class FEELStaticTypeTest
                   }} },
                 
                 { "{ myFeelVar : person.first name + person.last name + \" resides in \" + person.home address.street name }",
-                      new HashMap<String, Type>() {{
-                          put( "person", new JavaBackedType(Person.class) );
-                      }},
-                      new HashMap<String, Object>() {{
-                          put( "person", new Person("John ", "Doe", new Address("Lumbard St.")) ); 
-                      }},
-                      new HashMap<String,Object>() {{
-                          put( "myFeelVar", "John Doe resides in Lumbard St." );
-                      }} }
+                  new HashMap<String, Type>() {{
+                      put( "person", JavaBackedType.of(Person.class) );
+                  }},
+                  new HashMap<String, Object>() {{
+                      put( "person", new Person("John ", "Doe", new Address("Lumbard St.")) ); 
+                  }},
+                  new HashMap<String,Object>() {{
+                      put( "myFeelVar", "John Doe resides in Lumbard St." );
+                  }} },
+                
+                { "{ myFeelVar : person.age }",
+                  new HashMap<String, Type>() {{
+                      put( "person", JavaBackedType.of(Person.class) );
+                  }},
+                  new HashMap<String, Object>() {{
+                      put( "person", new Person("John ", "Doe", 47) ); 
+                  }},
+                  new HashMap<String,Object>() {{
+                      put( "myFeelVar", new BigDecimal(47) );
+                  }} },
+                
+                { "{ myFeelVar : person.first name + \"zip code is: \" + person.home address.zip }",
+                  new HashMap<String, Type>() {{
+                      put( "person", JavaBackedType.of(Person.class) );
+                  }},
+                  new HashMap<String, Object>() {{
+                      put( "person", new Person("John ", "Doe", new Address("Lumbard St.", "12345")) ); 
+                  }},
+                  new HashMap<String,Object>() {{
+                      put( "myFeelVar", "John zip code is: 12345" );
+                  }} }
+                
                 
         };
         return Arrays.asList( cases );

--- a/kie-dmn-feel/src/test/java/test/Address.java
+++ b/kie-dmn-feel/src/test/java/test/Address.java
@@ -4,10 +4,17 @@ import org.kie.dmn.feel.lang.FEELProperty;
 
 public class Address {
     private String streetName;
+    private String zip;
 
     public Address(String streetName) {
         super();
         this.streetName = streetName;
+    }
+    
+    public Address(String streetName, String zip) {
+        super();
+        this.streetName = streetName;
+        this.zip = zip;
     }
 
     @FEELProperty("street name")
@@ -25,5 +32,14 @@ public class Address {
         builder.append("Address [streetName=").append(streetName).append("]");
         return builder.toString();
     }
+
+    public String getZip() {
+        return zip;
+    }
+    
+    public void setZip(String zip) {
+        this.zip = zip;
+    }
+    
     
 }

--- a/kie-dmn-feel/src/test/java/test/Person.java
+++ b/kie-dmn-feel/src/test/java/test/Person.java
@@ -6,6 +6,7 @@ public class Person {
     private String firstName;
     private String lastName;
     private Address homeAddress;
+    private int age;
     
     public Person(String firstName, String lastName) {
         super();
@@ -18,6 +19,11 @@ public class Person {
         this.homeAddress = homeAddress;
     }
     
+    public Person(String firstName, String lastName, int age) {
+        this(firstName, lastName);
+        this.setAge(age);
+    }
+
     @FEELProperty("first name")
     public String getFirstName() {
         return firstName;
@@ -50,6 +56,14 @@ public class Person {
         StringBuilder builder = new StringBuilder();
         builder.append("Person [firstName=").append(firstName).append(", lastName=").append(lastName).append("]");
         return builder.toString();
+    }
+
+    public int getAge() {
+        return age;
+    }
+
+    public void setAge(int age) {
+        this.age = age;
     }
     
 }


### PR DESCRIPTION
Now, to create a JavaBackedType, the method `JavaBackedType.of` must
be used which will memoize if necessary the result.

The method `JavaBackedType.of` returns a BuiltInType.UNKNOWN if it is
not possible to represent Class<> as a JavaBackedType.

The criteria if a Class<> can be represented as a JavaBackedType is 
currently implemented in `JavaBackedType.createIfAnnotated`

Added test to demonstrate currently not necessary to express properties
which are standard JavaBean compliant.
Only non-standard JavaBean compliant properties are currently needed
to be captured by JavaBackedType.