### PR TITLE
Refactoring FEELEventListenersManager.notifyListeners() .

### DIFF
--- a/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/FEELEventListenersManager.java
+++ b/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/impl/FEELEventListenersManager.java
@@ -23,6 +23,7 @@ import org.kie.dmn.feel.runtime.events.SyntaxErrorEvent;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.Supplier;
 
 public class FEELEventListenersManager {
 
@@ -69,5 +70,11 @@ public class FEELEventListenersManager {
                 // nothing to do
             }
         } );
+    }
+    
+    public static void notifyListeners(FEELEventListenersManager eventsManager, Supplier<FEELEvent> event) {
+        if( eventsManager != null && eventsManager.hasListeners() ) {
+            eventsManager.notifyListeners(event.get());
+        }
     }
 }

--- a/kie-dmn-feel/src/main/java/org/kie/dmn/feel/parser/feel11/FEELParser.java
+++ b/kie-dmn-feel/src/main/java/org/kie/dmn/feel/parser/feel11/FEELParser.java
@@ -104,15 +104,15 @@ public class FEELParser {
 
         @Override
         public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol, int line, int charPositionInLine, String msg, RecognitionException e) {
-            if( eventsManager != null && eventsManager.hasListeners() ) {
-                SyntaxErrorEvent event = new SyntaxErrorEvent( FEELEvent.Severity.ERROR,
-                                                               msg,
-                                                               e,
-                                                               line,
-                                                               charPositionInLine,
-                                                               offendingSymbol );
-                eventsManager.notifyListeners( event );
-            }
+            FEELEventListenersManager.notifyListeners( eventsManager , () -> {
+                return new SyntaxErrorEvent( FEELEvent.Severity.ERROR,
+                                             msg,
+                                             e,
+                                             line,
+                                             charPositionInLine,
+                                             offendingSymbol );
+                }
+            );
         }
     }
 

--- a/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/decisiontables/HitPolicy.java
+++ b/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/decisiontables/HitPolicy.java
@@ -17,6 +17,7 @@
 package org.kie.dmn.feel.runtime.decisiontables;
 
 import org.kie.dmn.feel.lang.EvaluationContext;
+import org.kie.dmn.feel.lang.impl.FEELEventListenersManager;
 import org.kie.dmn.feel.runtime.events.FEELEvent;
 import org.kie.dmn.feel.runtime.events.HitPolicyViolationEvent;
 import org.kie.dmn.feel.runtime.events.InvalidInputEvent;
@@ -111,15 +112,15 @@ public enum HitPolicy {
                                 List<DTDecisionRule> matches,
                                 List<Object> results) {
         if ( matches.size() > 1 ) {
-            if ( ctx.getEventsManager() != null && !ctx.getEventsManager().getListeners().isEmpty() ) {
+            FEELEventListenersManager.notifyListeners(ctx.getEventsManager(), () -> {
                 List<Integer> ruleMatches = matches.stream().map( m -> m.getIndex() ).collect(toList());
-                HitPolicyViolationEvent iie = new HitPolicyViolationEvent( FEELEvent.Severity.ERROR,
-                                                                           "UNIQUE hit policy decision tables can only have one matching rule. "+
-                                                                           "Multiple matches found for decision table '"+dt.getName()+"'. Matched rules: "+ruleMatches,
-                                                                           dt.getName(),
-                                                                           ruleMatches );
-                ctx.getEventsManager().notifyListeners( iie );
-            }
+                return new HitPolicyViolationEvent( FEELEvent.Severity.ERROR,
+                                                    "UNIQUE hit policy decision tables can only have one matching rule. "+
+                                                    "Multiple matches found for decision table '"+dt.getName()+"'. Matched rules: "+ruleMatches,
+                                                    dt.getName(),
+                                                    ruleMatches );
+                }
+            );
             return null;
         }
         if ( matches.size() == 1 ) {


### PR DESCRIPTION
@etirelli I prefer to submit this early to get your feedback please.

I've refactored the `notifyListener` logic in one place (a static method - a function).

I've used the Java 8's Supplier so the event to be dispatched is computed (created a `new` instance) if and only if the event manager is not null and there are listeners. This would keep the logic and optimization of "return early" as it was before, but instead of having it in several places, is just consolidated in the new function `FEELEventListenersManager.notifyListeners(FEELEventListenersManager eventsManager, Supplier<FEELEvent> event)`