### PR TITLE
Refactor to avoid "An invalid XML character (Unicode: 0x8)" in surefi…

### DIFF
--- a/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELStringOperationsTest.java
+++ b/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELStringOperationsTest.java
@@ -16,22 +16,44 @@
 
 package org.kie.dmn.feel.runtime;
 
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
 import java.util.Arrays;
 import java.util.Collection;
+
+import org.junit.Test;
 import org.junit.runners.Parameterized;
+import org.kie.dmn.feel.FEEL;
 
-public class FEELStringOperationsTest extends BaseFEELTest {
-
-    @Parameterized.Parameters(name = "{index}: {0} ({1}) = {2}")
-    public static Collection<Object[]> data() {
-        final Object[][] cases = new Object[][] {
-                // string concatenation
-                { "\"foo\"+\"bar\"", "foobar" },
-                // string escapes
-                { "\"string with \\\"quotes\\\"\"", "string with \"quotes\""},
-                { "\"a\\b\\t\\n\\f\\r\\\"\\'\\\\\\u2202b\"", "a\b\t\n\f\r\"\'\\\u2202b"}
-        };
-        return Arrays.asList( cases );
+public class FEELStringOperationsTest {
+    
+    private final FEEL feel = FEEL.newInstance();
+    
+    /**
+     * Avoid using JUnit's @Parameterized runner as String escape would trigger problem for rendering the actual test method
+     * for instance in JUnit runner IDE GUIs, and in surefire-report which would cause further problem in Jenkins.
+     */
+    @Test
+    public void testStringOperations() {
+        // string concatenation
+        assertResult("\"foo\"+\"bar\"", "foobar");
+        
+        // string escapes
+        assertResult( "\"string with \\\"quotes\\\"\"",          "string with \"quotes\""   );
+        assertResult( "\"a\\b\\t\\n\\f\\r\\\"\\'\\\\\\u2202b\"", "a\b\t\n\f\r\"\'\\\u2202b" );
+    }
+    
+    private void assertResult( String expression, Object result ) {
+        if( result == null ) {
+            assertThat( "Evaluating: '" + expression + "'", feel.evaluate( expression ), is( nullValue() ) );
+        } else if( result instanceof Class<?> ) {
+            assertThat( "Evaluating: '" + expression + "'", feel.evaluate( expression ), is( instanceOf( (Class<?>) result ) ) );
+        } else {
+            assertThat( "Evaluating: '"+expression+"'", feel.evaluate( expression ), is( result ) );
+        }
     }
 }
 

--- a/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELStringOperationsTest.java
+++ b/kie-dmn-feel/src/test/java/org/kie/dmn/feel/runtime/FEELStringOperationsTest.java
@@ -16,44 +16,26 @@
 
 package org.kie.dmn.feel.runtime;
 
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
-
 import java.util.Arrays;
 import java.util.Collection;
-
-import org.junit.Test;
 import org.junit.runners.Parameterized;
-import org.kie.dmn.feel.FEEL;
 
-public class FEELStringOperationsTest {
-    
-    private final FEEL feel = FEEL.newInstance();
+public class FEELStringOperationsTest extends BaseFEELTest {
     
     /**
-     * Avoid using JUnit's @Parameterized runner as String escape would trigger problem for rendering the actual test method
-     * for instance in JUnit runner IDE GUIs, and in surefire-report which would cause further problem in Jenkins.
+     * WARNING: do not use as JUNit's @Parameters name the index {1} within this test class, as this would result in invalid character in the XML surefire-report
+     * Original error was: An invalid XML character (Unicode: 0x8) was found in the value of attribute "name" and element is "testcase".
      */
-    @Test
-    public void testStringOperations() {
-        // string concatenation
-        assertResult("\"foo\"+\"bar\"", "foobar");
-        
-        // string escapes
-        assertResult( "\"string with \\\"quotes\\\"\"",          "string with \"quotes\""   );
-        assertResult( "\"a\\b\\t\\n\\f\\r\\\"\\'\\\\\\u2202b\"", "a\b\t\n\f\r\"\'\\\u2202b" );
-    }
-    
-    private void assertResult( String expression, Object result ) {
-        if( result == null ) {
-            assertThat( "Evaluating: '" + expression + "'", feel.evaluate( expression ), is( nullValue() ) );
-        } else if( result instanceof Class<?> ) {
-            assertThat( "Evaluating: '" + expression + "'", feel.evaluate( expression ), is( instanceOf( (Class<?>) result ) ) );
-        } else {
-            assertThat( "Evaluating: '"+expression+"'", feel.evaluate( expression ), is( result ) );
-        }
+    @Parameterized.Parameters(name = "{index}: {0} ")
+    public static Collection<Object[]> data() {
+        final Object[][] cases = new Object[][] {
+                // string concatenation
+                { "\"foo\"+\"bar\"", "foobar" },
+                // string escapes
+                { "\"string with \\\"quotes\\\"\"", "string with \"quotes\""},
+                { "\"a\\b\\t\\n\\f\\r\\\"\\'\\\\\\u2202b\"", "a\b\t\n\f\r\"\'\\\u2202b"}
+        };
+        return Arrays.asList( cases );
     }
 }
 


### PR DESCRIPTION
…re-report.

I think Jenkins build is broken because it is trying to read surefire-report file in `target/surefire-reports/TEST-org.kie.dmn.feel.runtime.FEELStringOperationsTest.xml`.

Which contains in the element _attribute_ value an invalid XML1.0 character. The error is like this:

> An invalid XML character (Unicode: 0x8) was found in the value of attribute "name" and element is "testcase".

And I can get analogous issues in my IDE for instance notice here:
![image](https://cloud.githubusercontent.com/assets/1699252/20798317/bd4516ae-b7de-11e6-8329-83f651914dbb.png)

and the same if I try to open the surefire-report xml file:
![image](https://cloud.githubusercontent.com/assets/1699252/20798362/db69459c-b7de-11e6-921a-d0309c6ac099.png)

with this PR I propose to "dodge" this issue by avoid the use of the JUnit `Parameterized` runner, and have vanilla JUnit test run. This would make the display of the report with the IDE GUIs working and XML free of the parser error due to the invalid XML character, e.g.:
![image](https://cloud.githubusercontent.com/assets/1699252/20798615/bc8327fa-b7df-11e6-93da-31730b75dbac.png)

This is in my perspective the easier solution given it applies only as the string escaping test do use special characters which appears (as per XML message above) invalid. 

I did a small research online but I wasn't able to find any straightforward solution, I'm wondering if the only way would be to modify the surefire-report generator to deal with the case of the special Unicode character which is an invalid XML element attribute value (so cannot be wrapped in a CDATA) - in order to deal with the specific test case we are implementing here (FEEL String escape tests).

@baldimir @psiroky what do you think, please?