### PR TITLE
Derive FEEL DecisionTable name from the Context entry variable name

### DIFF
--- a/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/ContextNode.java
+++ b/kie-dmn-feel/src/main/java/org/kie/dmn/feel/lang/ast/ContextNode.java
@@ -19,6 +19,7 @@ package org.kie.dmn.feel.lang.ast;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.kie.dmn.feel.lang.EvaluationContext;
 import org.kie.dmn.feel.runtime.functions.CustomFEELFunction;
+import org.kie.dmn.feel.runtime.functions.DTInvokerFunction;
 import org.kie.dmn.feel.runtime.functions.JavaFunction;
 import org.kie.dmn.feel.util.EvalHelper;
 
@@ -61,6 +62,8 @@ public class ContextNode
                     ((CustomFEELFunction) value).setName( name );
                 } else if( value instanceof JavaFunction ) {
                     ((JavaFunction) value).setName( name );
+                } else if ( value instanceof DTInvokerFunction ) {
+                    ((DTInvokerFunction) value).setName(name);
                 }
 
                 ctx.setValue( name, value );

--- a/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/decisiontables/DecisionTableImpl.java
+++ b/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/decisiontables/DecisionTableImpl.java
@@ -244,6 +244,10 @@ public class DecisionTableImpl {
     public HitPolicy getHitPolicy() {
         return hitPolicy;
     }
+    
+    public void setName(String name) {
+        this.name = name;
+    }
 
     public String getName() {
         return name;
@@ -256,4 +260,9 @@ public class DecisionTableImpl {
     public List<String> getParameterNames() {
         return parameterNames;
     }
+
+    public String getSignature() {
+        return getName() + "( " + parameterNames.stream().collect( Collectors.joining( ", " ) ) + " )";
+    }
+
 }

--- a/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/DTInvokerFunction.java
+++ b/kie-dmn-feel/src/main/java/org/kie/dmn/feel/runtime/functions/DTInvokerFunction.java
@@ -68,4 +68,15 @@ public class DTInvokerFunction
     public List<List<String>> getParameterNames() {
         return Collections.singletonList( dt.getParameterNames() );
     }
+
+    @Override
+    public void setName(String name) {
+        super.setName(name);
+        dt.setName(name);
+    }
+    
+    @Override
+    public String toString() {
+        return "decision table " + dt.getSignature();
+    }
 }


### PR DESCRIPTION
Example with test output for the FEEL context.
Before:

```
{
    myDecisionTable: org.kie.dmn.feel.runtime.functions.DTInvokerFunction@1a38ba58
    biggerDecisionTable: org.kie.dmn.feel.runtime.functions.DTInvokerFunction@3ad394e6
    multipleOutputs: org.kie.dmn.feel.runtime.functions.DTInvokerFunction@6058e535
    multipleInOut: org.kie.dmn.feel.runtime.functions.DTInvokerFunction@42deb43a
    result1: Adult
    result2: Medium
    result3: {
        Out2: out2b
        Out1: out1b
    }
    result4: {
        Out2: io2a
        Out1: io1a
    }
}
```

After:

```
{
    myDecisionTable: decision table myDecisionTable( Age )
    biggerDecisionTable: decision table biggerDecisionTable( Applicant Age, Medical History )
    multipleOutputs: decision table multipleOutputs( In1 )
    multipleInOut: decision table multipleInOut( In1, In2 )
    result1: Adult
    result2: Medium
    result3: {
        Out2: out2b
        Out1: out1b
    }
    result4: {
        Out2: io2a
        Out1: io1a
    }
}
```