### PR TITLE
Report error if two distinct resources define same DMN model name

### DIFF
--- a/kie-dmn-core/src/main/java/org/kie/dmn/core/assembler/DMNAssemblerService.java
+++ b/kie-dmn-core/src/main/java/org/kie/dmn/core/assembler/DMNAssemblerService.java
@@ -26,13 +26,16 @@ import org.kie.api.io.ResourceType;
 import org.kie.dmn.core.api.DMNCompiler;
 import org.kie.dmn.core.api.DMNFactory;
 import org.kie.dmn.core.api.DMNModel;
+import org.kie.dmn.core.impl.DMNKnowledgeBuilderError;
 import org.kie.dmn.core.impl.DMNPackageImpl;
 import org.kie.internal.assembler.KieAssemblerService;
 import org.kie.internal.builder.KnowledgeBuilder;
+import org.kie.internal.builder.KnowledgeBuilderResult;
 import org.kie.internal.io.ResourceTypePackage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Arrays;
 import java.util.Map;
 
 public class DMNAssemblerService implements KieAssemblerService {
@@ -66,9 +69,17 @@ public class DMNAssemblerService implements KieAssemblerService {
             if ( dmnpkg == null ) {
                 dmnpkg = new DMNPackageImpl( namespace );
                 rpkg.put(ResourceType.DMN, dmnpkg);
+            } else {
+                if ( dmnpkg.getModel( model.getName() ) != null) {
+                    ((KnowledgeBuilderImpl) kbuilder).updateResults(Arrays.asList(new KnowledgeBuilderResult[]{
+                            new DMNKnowledgeBuilderError(resource, namespace, "Duplicate model name " + model.getName() + " in namespace " + namespace)}));
+                    logger.error( "Duplicate model name {} in namespace {}", model.getName(), namespace );
+                }
             }
             dmnpkg.addModel( model.getName(), model );
         } else {
+            ((KnowledgeBuilderImpl) kbuilder).updateResults(Arrays.asList(new KnowledgeBuilderResult[]{
+                    new DMNKnowledgeBuilderError(resource, "Unable to compile DMN model for the resource")}));
             logger.error( "Unable to compile DMN model for resource {}", resource.getSourcePath() );
         }
     }

--- a/kie-dmn-core/src/main/java/org/kie/dmn/core/assembler/DMNAssemblerService.java
+++ b/kie-dmn-core/src/main/java/org/kie/dmn/core/assembler/DMNAssemblerService.java
@@ -70,16 +70,14 @@ public class DMNAssemblerService implements KieAssemblerService {
                 dmnpkg = new DMNPackageImpl( namespace );
                 rpkg.put(ResourceType.DMN, dmnpkg);
             } else {
-                if ( dmnpkg.getModel( model.getName() ) != null) {
-                    ((KnowledgeBuilderImpl) kbuilder).updateResults(Arrays.asList(new KnowledgeBuilderResult[]{
-                            new DMNKnowledgeBuilderError(resource, namespace, "Duplicate model name " + model.getName() + " in namespace " + namespace)}));
+                if ( dmnpkg.getModel( model.getName() ) != null ) {
+                    ((KnowledgeBuilderImpl) kbuilder).addBuilderResult(new DMNKnowledgeBuilderError(resource, namespace, "Duplicate model name " + model.getName() + " in namespace " + namespace));
                     logger.error( "Duplicate model name {} in namespace {}", model.getName(), namespace );
                 }
             }
             dmnpkg.addModel( model.getName(), model );
         } else {
-            ((KnowledgeBuilderImpl) kbuilder).updateResults(Arrays.asList(new KnowledgeBuilderResult[]{
-                    new DMNKnowledgeBuilderError(resource, "Unable to compile DMN model for the resource")}));
+            ((KnowledgeBuilderImpl) kbuilder).addBuilderResult(new DMNKnowledgeBuilderError(resource, "Unable to compile DMN model for the resource"));
             logger.error( "Unable to compile DMN model for resource {}", resource.getSourcePath() );
         }
     }

--- a/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNKnowledgeBuilderError.java
+++ b/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/DMNKnowledgeBuilderError.java
@@ -1,0 +1,47 @@
+package org.kie.dmn.core.impl;
+
+import org.drools.compiler.compiler.BaseKnowledgeBuilderResultImpl;
+import org.drools.compiler.compiler.DroolsError;
+import org.kie.api.io.Resource;
+import org.kie.internal.builder.KnowledgeBuilderError;
+import org.kie.internal.builder.ResultSeverity;
+
+
+public class DMNKnowledgeBuilderError extends DroolsError {
+
+    private int[] lines = new int[0];
+    private String message;
+    private String namespace;
+    
+    public DMNKnowledgeBuilderError(Resource resource, String namespace, String message) {
+        super(resource);
+        this.namespace = namespace;
+        this.message = message;
+    }
+    
+    public DMNKnowledgeBuilderError(Resource resource, String message) {
+        this(resource, "", message);
+    }
+
+    @Override
+    public ResultSeverity getSeverity() {
+        return ResultSeverity.ERROR;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+
+    @Override
+    public int[] getLines() {
+        return lines;
+    }
+
+    @Override
+    public String getNamespace() {
+        return this.namespace;
+    }
+
+    
+}

--- a/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNAssemblerTest.java
+++ b/kie-dmn-core/src/test/java/org/kie/dmn/core/DMNAssemblerTest.java
@@ -1,0 +1,31 @@
+package org.kie.dmn.core;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.kie.api.KieServices;
+import org.kie.api.builder.KieFileSystem;
+import org.kie.api.builder.Message.Level;
+import org.kie.api.builder.Results;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DMNAssemblerTest {
+    public static final Logger LOG = LoggerFactory.getLogger(DMNAssemblerTest.class);
+
+    @Test
+    public void testDuplicateModel() {
+        final KieServices ks = KieServices.Factory.get();
+        final KieFileSystem kfs = ks.newKieFileSystem();
+        
+        kfs.write(ks.getResources().newClassPathResource("0001-input-data-string.dmn", this.getClass()));
+        kfs.write(ks.getResources().newClassPathResource("duplicate.0001-input-data-string.dmn", this.getClass()));
+        
+        Results results = ks.newKieBuilder( kfs ).buildAll().getResults();
+        
+        LOG.info("buildAll() completed.");
+        results.getMessages(Level.ERROR).forEach( e -> LOG.error("{}", e));
+        
+        assertTrue( results.getMessages(Level.ERROR).size() > 0 );
+    }
+}

--- a/kie-dmn-core/src/test/resources/org/kie/dmn/core/duplicate.0001-input-data-string.dmn
+++ b/kie-dmn-core/src/test/resources/org/kie/dmn/core/duplicate.0001-input-data-string.dmn
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<definitions id="0001-input-data-string" name="0001-input-data-string"
+	namespace="https://github.com/droolsjbpm/kie-dmn"
+	xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
+	xmlns:feel="http://www.omg.org/spec/FEEL/20140401">
+	<decision name="Greeting Message" id="d_GreetingMessage">
+		<variable name="Greeting Message" typeRef="feel:string"/>
+		<informationRequirement>
+			<requiredInput href="#i_FullName"/>
+		</informationRequirement>
+		<literalExpression>
+			<text>"Hello " + Full Name</text>
+		</literalExpression>
+	</decision>
+	<inputData name="Full Name" id="i_FullName">
+		<variable name="Full Name" typeRef="feel:string"/>
+	</inputData>
+</definitions>


### PR DESCRIPTION
... in the same namespace.

Also, add KnowledgeBuilder errors from the DMNAssembler.

Align with droolsjbpm/drools#1083 .