### PR TITLE
Update Regex based implementation of EvalHelper#normalizeVariableName with faster one

### DIFF
--- a/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/EvalHelper.java
+++ b/kie-dmn-feel/src/main/java/org/kie/dmn/feel/util/EvalHelper.java
@@ -38,8 +38,25 @@ import java.util.stream.Stream;
 public class EvalHelper {
     public static final Logger LOG = LoggerFactory.getLogger( EvalHelper.class );
 
+    private static String removeBlankSpaces(String variableName) {
+        StringBuilder sb = new StringBuilder(variableName);
+        int j = 0;
+        boolean lastSpace = false;
+        for (int i = 0; i < sb.length(); i++) {
+            if (!Character.isWhitespace(sb.charAt(i))) {
+                sb.setCharAt(j++, sb.charAt(i));
+                lastSpace = false;
+            } else if (!lastSpace) {
+                sb.setCharAt(j++, sb.charAt(i));
+                lastSpace = true;
+            }
+        }
+        sb.delete(j, sb.length());
+        return sb.toString();
+    }
+
     public static String normalizeVariableName(String name) {
-        return name.replaceAll( "\\s+", " " );
+        return removeBlankSpaces(name);
     }
 
     public static BigDecimal getBigDecimalOrNull(Object value) {


### PR DESCRIPTION
I executed "0019-flight-rebooking.dmn" model in loop to measure kie-dmn performance.
Found out that regex in EvalHelper is responsible for 40% of processing. Consider using proposed implementation instead.