### PR TITLE
DROOLS-1435 fix REQAUTH_NOT_KNOWLEDGESOURCE when authorityRequirement ..

### DIFF
--- a/kie-dmn-validation/src/main/resources/rules.drl
+++ b/kie-dmn-validation/src/main/resources/rules.drl
@@ -228,7 +228,7 @@ end
 
 rule REQAUTH_NOT_KNOWLEDGESOURCE
 when
-  AuthorityRequirement( $oc: requiredAuthority )
+  AuthorityRequirement( requiredAuthority != null, $oc: requiredAuthority )
   DMNElement( id == rightOfHash( $oc.href ) , !(this instanceof KnowledgeSource) ) 
 then
   entryPoints["PROBLEMS"].insert( new ValidationMsg( Severity.ERROR, Msg.REQAUTH_NOT_KNOWLEDGESOURCE, $oc ) );

--- a/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorTest.java
+++ b/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorTest.java
@@ -332,6 +332,16 @@ public class ValidatorTest {
     }
     
     @Test
+    public void testREQAUTH_NOT_KNOWLEDGESOURCEbis() {
+        // DROOLS-1435
+        Definitions definitions = utilDefinitions( "REQAUTH_NOT_KNOWLEDGESOURCEbis.dmn", "REQAUTH_NOT_KNOWLEDGESOURCEbis" );
+        List<ValidationMsg> validate = validator.validateModel(definitions);
+
+        // this test should just pass without any NPE:
+        assertTrue( validate.size() > 0 );
+    }
+    
+    @Test
     public void testTYPEREF_NO_FEEL_TYPE() {
         Definitions definitions = utilDefinitions( "TYPEREF_NO_FEEL_TYPE.dmn", "TYPEREF_NO_FEEL_TYPE" );
         List<ValidationMsg> validate = validator.validateModel(definitions);

--- a/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/REQAUTH_NOT_KNOWLEDGESOURCEbis.dmn
+++ b/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/REQAUTH_NOT_KNOWLEDGESOURCEbis.dmn
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<definitions id="REQAUTH_NOT_KNOWLEDGESOURCEbis" name="REQAUTH_NOT_KNOWLEDGESOURCEbis"
+    namespace="https://github.com/droolsjbpm/kie-dmn"
+    xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
+    xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+  <businessKnowledgeModel name="bkm1">
+    <authorityRequirement>
+        <requiredInput href="#_90aab494-9458-4b43-bdf4-0a82c22761b3" />
+    </authorityRequirement>
+  </businessKnowledgeModel>
+  <knowledgeSource id="auth2" name="auth2"></knowledgeSource>
+  <textAnnotation id="auth1"></textAnnotation> <!-- TEST, should be an inputdata with the same ID -->
+</definitions>


### PR DESCRIPTION
.. is not a requiredAuthority but another valid node.