### PR TITLE
Fix ErraiApp.properties file following migration of QName 

### DIFF
--- a/kie-dmn-model/src/main/resources/ErraiApp.properties
+++ b/kie-dmn-model/src/main/resources/ErraiApp.properties
@@ -69,7 +69,6 @@ errai.marshalling.serializableTypes=org.kie.dmn.feel.model.v1_1.Artifact \
                                     org.kie.dmn.feel.model.v1_1.OrganizationUnit \
                                     org.kie.dmn.feel.model.v1_1.OutputClause \
                                     org.kie.dmn.feel.model.v1_1.PerformanceIndicator \
-                                    org.kie.dmn.feel.model.v1_1.QName \
                                     org.kie.dmn.feel.model.v1_1.Relation \
                                     org.kie.dmn.feel.model.v1_1.TextAnnotation \
                                     org.kie.dmn.feel.model.v1_1.UnaryTests


### PR DESCRIPTION
Complement commit 7262295 in migration from custom QName
to JRE's javax.xml.namespace.QName and misc, by removing the no longer
existing class.

As discussing on droolsjbpm/jbpm#746 for https://github.com/droolsjbpm/jbpm/pull/746#issuecomment-279451090

thanks @mswiderski for pointing out :)

cc/ @etirelli 