### PR TITLE
DROOLS-1437 Avoid stax-utils dependency by performing manual indentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,22 +87,11 @@
         <artifactId>kie-dmn-core</artifactId>
         <version>${version.org.kie}</version>
       </dependency>
-    <dependency>
-      <groupId>org.xmlunit</groupId>
-      <artifactId>xmlunit-core</artifactId>
-      <version>2.2.1</version>
-    </dependency>
-    <dependency>
-      <groupId>net.java.dev.stax-utils</groupId>
-      <artifactId>stax-utils</artifactId>
-      <version>20070216</version>
-      <exclusions>
-        <exclusion>
-        <groupId>com.bea.xml</groupId>
-        <artifactId>jsr173-ri</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
+      <dependency>
+        <groupId>org.xmlunit</groupId>
+        <artifactId>xmlunit-core</artifactId>
+        <version>2.2.1</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
Complement droolsjbpm/kie-dmn#37 that was missing to erase the 
stax-utils from the dependencyManagement .