### PR TITLE
Do not report redundant NAME_INVALID validation messages

### DIFF
--- a/kie-dmn-validation/src/main/resources/rules.drl
+++ b/kie-dmn-validation/src/main/resources/rules.drl
@@ -201,7 +201,7 @@ end
 
 rule NAME_INVALID
 when
-    $ne : NamedElement( parent != null, !(parent instanceof Decision),                       // << functional optimization to avoid double reporting as Decision name == variable name 
+    $ne : NamedElement( parent != null, !(parent instanceof DRGElement),                       // << functional optimization to avoid double reporting as Decision name == variable name 
                         FEELParser.isVariableNameValid( name ) == false )
 then
 //    java.util.List<FEELEvent> see = FEELParser.checkVariableName( $ne.getName() );

--- a/kie-dmn-validation/src/main/resources/rules.drl
+++ b/kie-dmn-validation/src/main/resources/rules.drl
@@ -201,7 +201,8 @@ end
 
 rule NAME_INVALID
 when
-    $ne : NamedElement( FEELParser.isVariableNameValid( name ) == false )
+    $ne : NamedElement( parent != null, !(parent instanceof Decision),                       // << functional optimization to avoid double reporting as Decision name == variable name 
+                        FEELParser.isVariableNameValid( name ) == false )
 then
 //    java.util.List<FEELEvent> see = FEELParser.checkVariableName( $ne.getName() );
 //    String customMessage = see.isEmpty()? Msg.NAME_INVALID : see.get(0).getMessage()

--- a/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorTest.java
+++ b/kie-dmn-validation/src/test/java/org/kie/dmn/validation/ValidatorTest.java
@@ -315,6 +315,21 @@ public class ValidatorTest {
     }
     
     @Test
+    public void testNAME_INVALID_bis() {
+        Definitions definitions = utilDefinitions( "NAME_INVALID_bis.dmn", "code in list of codes" );
+        List<ValidationMsg> validate = validator.validateModel(definitions);
+        
+        assertTrue( validate.stream().anyMatch( p -> p.getMessage().equals( Msg.NAME_INVALID ) ) );
+        
+        /* in the file NAME_INVALID_bis.dmn there are 3 invalid "names" but only the one for the Decision node should be reported.
+         * <definitions id="NAME_INVALID" name="code in list of codes" ...
+            <decision name="code in list of codes" id="d_GreetingMessage">
+             <variable name="code in list of codes" typeRef="feel:string"/>
+         */
+        assertEquals("functional optimization of valid names to report ", 1, validate.stream().filter( p -> p.getMessage().equals( Msg.NAME_INVALID ) ).count() );
+    }
+    
+    @Test
     public void testRELATION_DUP_COLUMN() {
         Definitions definitions = utilDefinitions( "RELATION_DUP_COLUMN.dmn", "RELATION_DUP_COLUMN" );
         List<ValidationMsg> validate = validator.validateModel(definitions);

--- a/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/NAME_INVALID_bis.dmn
+++ b/kie-dmn-validation/src/test/resources/org/kie/dmn/validation/NAME_INVALID_bis.dmn
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+  
+<definitions id="NAME_INVALID" name="code in list of codes"
+    namespace="https://github.com/droolsjbpm/kie-dmn"
+    xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
+    xmlns:feel="http://www.omg.org/spec/FEEL/20140401"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.omg.org/spec/DMN/20151101/dmn.xsd http://www.omg.org/spec/DMN/20151101/dmn.xsd ">
+    <decision name="code in list of codes" id="d_GreetingMessage">
+        <variable name="code in list of codes" typeRef="feel:string"/>
+        <informationRequirement>
+            <requiredInput href="#i_FullName"/>
+        </informationRequirement>
+        <literalExpression>
+            <text>"Hello " + Full Name</text>
+        </literalExpression>
+    </decision>
+    <inputData name="Full Name" id="i_FullName">
+        <variable name="Full Name" typeRef="feel:string"/>
+    </inputData>
+</definitions>


### PR DESCRIPTION
Do not report NAME_INVALID validation twice for Decision name and the
companion Decision's variable name.

Additionally, do not report NAME_INVALID for root note Definitions node.